### PR TITLE
ci: run push builds on the default branch only

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,8 +2,7 @@ name: Go CI
 
 on:
   push:
-    branches:
-      - '**'
+    branches: [main]
 #    branches-ignore:
 #      - renovate/**
     tags:


### PR DESCRIPTION
A PR branch fired both the `push` and the `pull_request` trigger, so every PR produced two identical runs. Restricting `push:` to the default branch leaves `pull_request` as the single PR signal and keeps the post-merge run on main.

Workflow config only. YAML validated with `yaml.safe_load` before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXqd1buVpwVWjyGYESYh82